### PR TITLE
leverage object properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,8 @@ app.set("view engine", "ejs");
 app.set("views", path.join(__dirname, "public"));
 
 app.get("/:a/:b/:c/:d/:e/:f/:g/:h", (req, res) => {
-  const { a, b, c, d, e, f, g, h } = req.params;
-  res.redirect(`/?fen=${[a, b, c, d, e, f, g, h].join("/")}`);
+  const fen = Object.values(req.params).join("/");
+  res.redirect(`/?fen=${fen}`);
 });
 
 app.get("/", (req, res) => {


### PR DESCRIPTION
We know that object preserve order of insertion. So, instead of using object destructuring. I use Object.values to gather path segments and then join it as previously done.